### PR TITLE
Adds CNI Delete support

### DIFF
--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -25,6 +25,8 @@ import (
 type Driver interface {
 	Connect() *grpc.ClientConn
 	RenderModules(module []network.PipelineModule) error
+	DeleteModules(modules []network.PipelineModule, egress bool) error
+	DeletePort(name string) error
 	AddEntryL2FIB(module *network.Switch, macAddr string, gate network.Gate) error
 }
 


### PR DESCRIPTION
Now CNI delete will correctly remove modules/port for a pipeline in
BESS. Also includes:

 - A fix for CNI Add where the CIDR mask was missing in the CNI Reply
for the IP Address.
 - Mutex fixes where the pipelines were not being locked in time causing
   race conditions.

Signed-off-by: Tim Rozet <trozet@redhat.com>