### PR TITLE
Adds Kernel Port(s) to default CNI network

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -48,7 +48,6 @@ func selectDriver(config *agent.NimbessConfig) drivers.Driver {
 		TunnelMode:  config.TunnelMode,
 		FIBSize:     config.FIBSize,
 		Port:        config.DataPlanePort,
-		PCIDevices:  config.NICs,
 		WorkerCores: config.WorkerCores,
 	}
 	switch config.DataPlane {
@@ -82,7 +81,7 @@ func main() {
 	log.SetOutput(mw)
 	// TODO make this log level configurable
 	log.SetLevel(log.DebugLevel)
-
+	log.SetReportCaller(true)
 	nimbessConfig := agent.InitConfig(*confFile)
 	driver := selectDriver(nimbessConfig)
 	// Create Pipeline map of per port pipelines

--- a/k8s/nimbess.yaml
+++ b/k8s/nimbess.yaml
@@ -14,7 +14,7 @@ data:
         "log_level": "info",
         "grpcServer": "localhost:9111",
         "ipam": {
-            "type": "whereabouts"
+            "type": "nimbess"
         }
     }
 
@@ -50,9 +50,34 @@ spec:
         - operator: Exists
           effect: NoSchedule
       containers:
+        - name: bess
+          image: nimbess/bess
+          command: ["./bin/bessd"]
+          args: ["-f", "-log_dir", "/var/log/bess"]
+          securityContext:
+            privileged: true
+          resources:
+            requests:
+              hugepages-2Mi: 1Gi
+              memory: 2Gi
+            limits:
+              hugepages-2Mi: 1Gi
+              memory: 2Gi
+          volumeMounts:
+            - mountPath: /dev/hugepages
+              name: hugepages
+            - mountPath: /host/proc
+              name: proc-dir
         - name: nimbess-agent
           image: nimbess/nimbess-agent
           command: ["/nimbess-agent"]
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: /etc/nimbess/agent/
+              name: agent-conf-dir
+            - mountPath: /host/proc
+              name: proc-dir
         # This container installs the Nimbess CNI binary
         # and CNI network config file on each node.
         - name: install-cni
@@ -78,3 +103,12 @@ spec:
         - name: cni-net-dir
           hostPath:
             path: /etc/cni/net.d
+        - name: hugepages
+          hostPath:
+            path: /dev/hugepages
+        - name: proc-dir
+          hostPath:
+            path: /proc
+        - name: agent-conf-dir
+          hostPath:
+            path: /etc/nimbess/agent/

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -43,11 +43,12 @@ type Network struct {
 
 // NimbessConfig contains the generic Nimbess Agent configuration.
 type NimbessConfig struct {
-	Port          int      `mapstructure:"agent_port"`
-	DataPlane     string   `mapstructure:"data_plane"`
-	DataPlanePort int      `mapstructure:"data_plane_port"`
-	WorkerCores   []int64  `mapstructure:"worker_cores"`
-	NICs          []string `mapstructure:"pci_devices"`
+	Port          int     `mapstructure:"agent_port"`
+	DataPlane     string  `mapstructure:"data_plane"`
+	DataPlanePort int     `mapstructure:"data_plane_port"`
+	WorkerCores   []int64 `mapstructure:"worker_cores"`
+	KernelIF      string  `mapstructure:"kernel_interface"`
+	FastPathIF    string  `mapstructure:"high_speed_interface"`
 	Network
 }
 
@@ -78,7 +79,7 @@ func InitConfig(cfgPath string) *NimbessConfig {
 	if err != nil {
 		log.Fatalf("Unable to parse Nimbess config: %v", err)
 	} else {
-		log.Infof("Configuration parsed as: +%v", cfg)
+		log.Infof("Configuration parsed as: %+v", cfg)
 	}
 	return cfg
 }

--- a/pkg/drivers/driver.go
+++ b/pkg/drivers/driver.go
@@ -28,6 +28,7 @@ type Driver interface {
 	DeleteModules(modules []network.PipelineModule, egress bool) error
 	DeletePort(name string) error
 	AddEntryL2FIB(module *network.Switch, macAddr string, gate network.Gate) error
+	Commit() error
 }
 
 // DriverConfig represents the generic driver configuration required by Driver.
@@ -37,6 +38,5 @@ type DriverConfig struct {
 	TunnelMode  bool
 	FIBSize     int64
 	Port        int
-	PCIDevices  []string
 	WorkerCores []int64
 }

--- a/pkg/network/modules.go
+++ b/pkg/network/modules.go
@@ -68,6 +68,7 @@ type Port struct {
 	NamesSpace string
 	IPAddr     string
 	MacAddr    string
+	Gateway    string
 }
 
 // IngressPort represents the RX side of a network interface

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -16,6 +16,52 @@
 			"revisionTime": "2018-11-01T15:39:34Z"
 		},
 		{
+			"checksumSHA1": "Dhi4+8X7U2oVzVkgxPrmLaN8qFI=",
+			"origin": "github.com/containernetworking/plugins/vendor/github.com/containernetworking/cni/pkg/types",
+			"path": "github.com/containernetworking/cni/pkg/types",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
+			"checksumSHA1": "6+ng8oaM9SB0TyCE7I7N940IpPY=",
+			"origin": "github.com/containernetworking/plugins/vendor/github.com/containernetworking/cni/pkg/types/020",
+			"path": "github.com/containernetworking/cni/pkg/types/020",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
+			"checksumSHA1": "X6dNZ3yc3V9ffW9vz4yIyeKXGD0=",
+			"origin": "github.com/containernetworking/plugins/vendor/github.com/containernetworking/cni/pkg/types/current",
+			"path": "github.com/containernetworking/cni/pkg/types/current",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
+			"checksumSHA1": "LTsIp3CxydS38W9whhqj4aWShBg=",
+			"path": "github.com/containernetworking/plugins/pkg/ip",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
+			"checksumSHA1": "n3dCDigZOU+eD84Cr4Kg30GO4nI=",
+			"path": "github.com/containernetworking/plugins/pkg/ns",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
+			"checksumSHA1": "rUAk+nce6eDIWtYo/QYIoqlTfrY=",
+			"path": "github.com/containernetworking/plugins/pkg/utils/hwaddr",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
+			"checksumSHA1": "tKFoM5uHIwiddsEpOadY325vURI=",
+			"origin": "github.com/containernetworking/plugins/vendor/github.com/coreos/go-iptables/iptables",
+			"path": "github.com/coreos/go-iptables/iptables",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
 			"checksumSHA1": "Gj+xR1VgFKKmFXYOJMnAczC3Znk=",
 			"origin": "github.com/docker/docker/vendor/github.com/docker/distribution/digestset",
 			"path": "github.com/docker/distribution/digestset",
@@ -333,6 +379,13 @@
 			"revisionTime": "2018-11-01T15:39:34Z"
 		},
 		{
+			"checksumSHA1": "sdkUNIxS+39OB5wZ+6+A/QAh/PA=",
+			"origin": "github.com/containernetworking/plugins/vendor/github.com/safchain/ethtool",
+			"path": "github.com/safchain/ethtool",
+			"revision": "966bbcb8a572aa4c253ea9650888ad2306e3c8f2",
+			"revisionTime": "2019-07-10T15:04:52Z"
+		},
+		{
 			"checksumSHA1": "SVO+Zm6SNwWrpgyc6mcTXbH4aJ8=",
 			"path": "github.com/sirupsen/logrus",
 			"revision": "2a22dbedbad1fd454910cd1f44f210ef90c28464",
@@ -373,6 +426,24 @@
 			"path": "github.com/spf13/viper",
 			"revision": "62edee319679b6ceaec16de03b966102d2dea709",
 			"revisionTime": "2018-09-30T04:41:27Z"
+		},
+		{
+			"checksumSHA1": "c0f+DTMGSevLzIjo6IsuzWQpMbc=",
+			"path": "github.com/vishvananda/netlink",
+			"revision": "aa5b058fc07b88462111aaf4f7c89f1caee9c990",
+			"revisionTime": "2018-09-30T20:42:25Z"
+		},
+		{
+			"checksumSHA1": "UuqmIIrT/U4WxsIG7TNEeAvFZ74=",
+			"path": "github.com/vishvananda/netlink/nl",
+			"revision": "aa5b058fc07b88462111aaf4f7c89f1caee9c990",
+			"revisionTime": "2018-09-30T20:42:25Z"
+		},
+		{
+			"checksumSHA1": "8Y8hkjXEkSXBzI/dIdJPXYlGu24=",
+			"path": "github.com/vishvananda/netns",
+			"revision": "13995c7128ccc8e51e9a6bd2b551020a27180abd",
+			"revisionTime": "2018-07-20T11:23:40Z"
 		},
 		{
 			"checksumSHA1": "7G5NVR7TOpJn0CSpofyLaDrZXMs=",


### PR DESCRIPTION
On default CNI network, a virtual port will be added to the host during
MetaPipeline create for a network. This port will receive an IP from
IPAM and will be used as the default gateway for the pods on this
network. This gives the pods host and egress via host access. This patch
adds configuring the default gateway for the pod namespace.

For the secondary interface (high speed/pod-to-pod) traffic, the
physical interface may be specified on the host. This interface should
be a DPDK or other type of high speed interface, but as a fallback
kernel_interface may be used in the agent config for testing
environments where it may not be possible to use DPDK, AF_XDP, or other
high speed technologies.

When specified in Agent config, a kernel interface will be added to the
default CNI network at the same time the first pod CNI ADD request is
received.

Other fixes include:
 - Switch module wiring fix: Now egress ports are correctly connected to
   both the replicate *and* the l2forward module. Previously they were
   only being connected to replicate module.
 - Replicate module fix: Replicate module was not correctly being set to
   replicate packets across all egress gates. This is fixed.
 - l2forward default gate fix: Default gate was never being set to
   replicate module, so traffic was not forwarding correctly.
 - MetaPipeline Egress port update fix: Slice was being incorrectly
   updated and the desired port was not being popped correctly.
 - CNI Del fix: During delete we were not removing the pointer linkage
   in the Egress port map to the deleted pipeline. Therefore following
   CNI Adds would fail during Egress Port link updates.
 - Mounting /proc into containers: /proc is currently needed by
   containers that need to modify namespaces. However mounting /proc
   directly as /proc into the container forces the pid of the container
   process to not be 1, as well as other side effects. Now /proc is
   mounted into containers as /host/proc.
 - Updated k8s config file with bess container.

Signed-off-by: Tim Rozet <trozet@redhat.com>