### PR TITLE
Fixes mounting of hugepages

### DIFF
--- a/k8s/nimbess.yaml
+++ b/k8s/nimbess.yaml
@@ -116,8 +116,8 @@ spec:
           hostPath:
             path: /etc/cni/net.d
         - name: hugepages
-          hostPath:
-            path: /dev/hugepages
+          emptyDir:
+            medium: HugePages
         - name: proc-dir
           hostPath:
             path: /proc


### PR DESCRIPTION
Mounting was previously done using the mounted file path, which caused
issues on some systems. This patch uses the recommended way of allowing
k8s to mount the hugepages.

Signed-off-by: Tim Rozet <trozet@redhat.com>